### PR TITLE
Revert "Link to TC39 spec"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ The process generally goes like this:
 * Positive consensus is reached, and the draft proposal is regarded up to snuff.
 * The proposal is incorporated into the specification.
 
-[spec]: https://tc39.es/source-map-spec/
+[spec]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#
 [issues]: https://github.com/source-map/source-map-rfc/issues


### PR DESCRIPTION
Reverts tc39/source-map-rfc#71, see discussion in that PR. I'll open a revert of the revert so we can discuss at the next meeting.