### PR TITLE
 Fix "This version" URL pointing to former source-map org

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -4,7 +4,7 @@ H1: Source Map
 Shortname: source-map
 Level: 1
 Status: STAGE0
-URL: https://source-map.github.io/source-map-spec/
+URL: https://tc39.github.io/source-map-spec/
 Editor: Armin Ronacher, Sentry
 Former Editor: Victor Porof, Google
 Former Editor: John Lenz, Google

--- a/source-map.bs
+++ b/source-map.bs
@@ -4,7 +4,7 @@ H1: Source Map
 Shortname: source-map
 Level: 1
 Status: STAGE0
-URL: https://tc39.github.io/source-map-spec/
+URL: https://tc39.es/source-map/
 Editor: Armin Ronacher, Sentry
 Former Editor: Victor Porof, Google
 Former Editor: John Lenz, Google


### PR DESCRIPTION
The old URL serves 404 Error now.