### PR TITLE
Scopes: Add 'file' scope

### DIFF
--- a/proposals/scopes.md
+++ b/proposals/scopes.md
@@ -100,7 +100,7 @@ More precisely, for every location `loc_gen` in the generated code that is mappe
   - if `loc_gen` is in an inlined function, the scopes in the original source which contain the function call that was inlined
 
 The following information describes a scope in the source map:
-- whether this is a function scope
+- the type ("kind") of a scope. The "global" scope refers to anything hoisted to `globalThis`, whereas "file" refers to the top-level scope of individual script files or ES modules.
 - whether bindings from outer scopes are accessible within this scope
 - whether the debugger should step over this scope
 - whether this scope should be shown among the original scopes
@@ -152,7 +152,7 @@ interface GeneratedRange {
   children?: GeneratedRange[];
 }
 
-type ScopeKind = 'global' | 'script' | 'module' | 'class' | 'function' | 'block';
+type ScopeKind = 'global' | 'file' | 'class' | 'function' | 'block';
 
 interface BindingRange {
   from: GeneratedPosition;
@@ -197,11 +197,10 @@ Note: Each DATA represents one VLQ number.
 * DATA kind
   * Note: This is type of the scope.
   * 0x1 global
-  * 0x2 script
-  * 0x3 module
-  * 0x4 class
-  * 0x5 function
-  * 0x6 block
+  * 0x2 file
+  * 0x3 class
+  * 0x4 function
+  * 0x5 block
 * DATA field flags
   * Note: binary flags that specify if a field is used for this scope.
   * Note: Unknown flags would skip the whole scope.

--- a/proposals/scopes.md
+++ b/proposals/scopes.md
@@ -152,7 +152,7 @@ interface GeneratedRange {
   children?: GeneratedRange[];
 }
 
-type ScopeKind = 'global' | 'class' | 'function' | 'block';
+type ScopeKind = 'global' | 'script' | 'module' | 'class' | 'function' | 'block';
 
 interface BindingRange {
   from: GeneratedPosition;
@@ -196,10 +196,12 @@ Note: Each DATA represents one VLQ number.
   * Note: Column is always absolute.
 * DATA kind
   * Note: This is type of the scope.
-  * 0x1 toplevel
-  * 0x2 function
-  * 0x3 class
-  * 0x4 block
+  * 0x1 global
+  * 0x2 script
+  * 0x3 module
+  * 0x4 class
+  * 0x5 function
+  * 0x6 block
 * DATA field flags
   * Note: binary flags that specify if a field is used for this scope.
   * Note: Unknown flags would skip the whole scope.


### PR DESCRIPTION
This is straw-man PR to discuss whether we want to distinguish "global" and "file" ("script" or "module") scope.

An example of this may be the following:

```js
// a.js
var foo = 'a';
const bar=  'b';
```

Both Firefox DevTools and Chrome DevTools would show different scopes for `a` and `b`. Specifically `a` would be in the "global" scope as it gets hoisted to `globalThis`/`window`. Whereas `b` would be only in the "script" scope.

This could simplify handling of the "global" scope across multiple authored files. To expand on the initial example let's add another file:

```js
// b.js
var fooB = 'foo';
const barB = 'bar';

debugger;
```

And the combined bundle:

```js
// bundle.js
var foo = 'a';
const bar=  'b';
var fooB = 'foo';
const barB = 'bar';

debugger;
```

If we pause on the debugger statement then the expected scope chain is:

* script
  * `barB: 'bar'`
* global
  * `foo: 'a'`
  * `fooB: 'foo'`

Since the global scope is combined. Generators can achieve this by generating the following "generated ranges" for the bundle:

```js
// bundle.js
var foo = 'a';      | (1)  | (2)  | (3)  
const bar=  'b';    |      |      |
var fooB = 'foo';   |      |             | (4)
const barB = 'bar'; |      |             |
                    |      |             |
debugger;           |      |             |  
```

(1) and (2) are the respective "global" scopes. (3) is the file scope of `a.js` and (4) is the file scope of `b.js`.