### PR TITLE
Revert spec change

### DIFF
--- a/README.rfcs.md
+++ b/README.rfcs.md
@@ -15,5 +15,5 @@ The process generally goes like this:
 * Positive consensus is reached, and the draft proposal is regarded up to snuff.
 * The proposal is incorporated into the specification.
 
-[spec]: https://tc39.es/source-map-spec/
+[spec]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#
 [issues]: https://github.com/source-map/source-map-rfc/issues


### PR DESCRIPTION
We changed the linked spec from the google doc to the current draft but received feedback we should revert for now. Between the change and the revert we combine the repositories so the revert got a bit messy. This reverts to the original link to the google doc as the spec.