### PR TITLE
Scopes: Update `kind` to be an arbitrary string in the `names` field

### DIFF
--- a/proposals/scopes.md
+++ b/proposals/scopes.md
@@ -152,8 +152,6 @@ interface GeneratedRange {
   children?: GeneratedRange[];
 }
 
-type ScopeKind = 'global' | 'class' | 'function' | 'block';
-
 interface BindingRange {
   from: GeneratedPosition;
   to: GeneratedPosition;
@@ -196,6 +194,7 @@ Note: Each DATA represents one VLQ number.
   * Note: Column is always absolute.
 * DATA kind offset into `names` field
   * Note: This is type of the scope.
+  * Note: JavaScript implementations should use `'global'`, `'class'`, `'function'`, and `'block'`.
 * DATA field flags
   * Note: binary flags that specify if a field is used for this scope.
   * Note: Unknown flags would skip the whole scope.

--- a/proposals/scopes.md
+++ b/proposals/scopes.md
@@ -125,7 +125,7 @@ interface SourceMap {
 interface OriginalScope {
   start: OriginalPosition;
   end: OriginalPosition;
-  kind: ScopeKind;
+  kind: string;
   /** Class/module/function name. Can be used for stack traces or naming scopes in a debugger's scope view */
   name?: string;
   /** Symbols defined in this scope */
@@ -194,12 +194,8 @@ Note: Each DATA represents one VLQ number.
   * Note: this is the point in the original code where the scope starts. `line` is relative to the `line` of the preceding "start/end original scope" item.
 * DATA column in the original code
   * Note: Column is always absolute.
-* DATA kind
+* DATA kind offset into `names` field
   * Note: This is type of the scope.
-  * 0x1 toplevel
-  * 0x2 function
-  * 0x3 class
-  * 0x4 block
 * DATA field flags
   * Note: binary flags that specify if a field is used for this scope.
   * Note: Unknown flags would skip the whole scope.

--- a/proposals/scopes.md
+++ b/proposals/scopes.md
@@ -193,6 +193,7 @@ Note: Each DATA represents one VLQ number.
 * DATA column in the original code
   * Note: Column is always absolute.
 * DATA kind offset into `names` field
+  * Note: This offset is relative to the offset of the last `kind` or absolute if this is the first `kind`.
   * Note: This is type of the scope.
   * Note: JavaScript implementations should use `'global'`, `'class'`, `'function'`, and `'block'`.
 * DATA field flags


### PR DESCRIPTION
This changes `kind` from an enum of known values, to be an index into the `names` field holding any arbitrary string. This allows us to better accommodate non-JS languages.