### PR TITLE
Add examples for Base64 VLQ encoding

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -148,7 +148,8 @@ The string `"iB"` represents a [=Base64 VLQ=] with two digits. The first digit
 `"i"` encodes the bit pattern `0x100010`, which has a continuation bit of `1` (the
 VLQ continues), a sign bit of `0` (non-negative), and the value bits `0x0001`.
 The second digit `B` encodes the bit pattern `0x000001`, which has a continuation
-bit of `0` and no sign bit. The decoding of this VLQ string is the number 17.
+bit of `0`, no sign bit, and value bits `0x00001`. The decoding of this VLQ string
+is the number 17.
 </div>
 
 <div class="example">

--- a/source-map.bs
+++ b/source-map.bs
@@ -143,6 +143,21 @@ Note: The values that can be represented by the VLQ Base64 encoded are limited t
 means that values exceeding 32-bits are invalid and implementations may reject
 them. The sign bit is counted towards the limit, but the continuation bits are not.
 
+<div class="example">
+The string `"iB"` represents a [=Base64 VLQ=] with two digits. The first digit
+`"i"` encodes the bit pattern `0x100010`, which has a continuation bit of `1` (the
+VLQ continues), a sign bit of `0` (non-negative), and the value bits `0x0001`.
+The second digit `B` encodes the bit pattern `0x000001`, which has a continuation
+bit of `0` and no sign bit. The decoding of this VLQ string is the number 17.
+</div>
+
+<div class="example">
+The string `"V"` represents a [=Base64 VLQ=] with one digit. The digit
+`"V"` encodes the bit pattern `0x010101`, which has a continuation bit of `0`
+(no continuation), a sign bit of `1` (negative), and the value bits `0x1010`.
+The decoding of this VLQ string is the number -10.
+</div>
+
 <dfn>Source Mapping URL</dfn> refers to the URL referencing
 the location of a source map from the [=Generated code=].
 


### PR DESCRIPTION
This PR adds some examples to the spec document for VLQ encoding.