### PR TITLE
[mappings] Define for each ECMAScript input element where mappings are allowed

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -43,6 +43,21 @@ urlPrefix:https://tc39.es/ecma262/#; type:dfn; spec:ecmascript
     url:prod-MultiLineComment; text:multi-line comment
     url:prod-MultiLineComment; text:multi-line comment
     url:sec-regexpbuiltinexec; text:RegExpBuiltinExec
+    url:prod-Comment; text:Comment
+    url:prod-DivPunctuator; text:DivPunctuator
+    url:prod-HashbangComment; text:HashbangComment
+    url:prod-IdentifierName; text:IdentifierName
+    url:prod-LineTerminator; text:LineTerminator
+    url:prod-NumericLiteral; text:NumericLiteral
+    url:prod-Punctuator; text:Punctuator
+    url:prod-PrivateIdentifier; text:PrivateIdentifier
+    url:prod-RegularExpressionLiteral; text:RegularExpressionLiteral
+    url:prod-RightBracePunctuator; text:RightBracePunctuator
+    url:prod-StringLiteral; text:StringLiteral
+    url:prod-Template; text:Template
+    url:prod-TemplateSubstitutionTail; text:TemplateSubstitutionTail
+    url:prod-WhiteSpace; text:WhiteSpace
+    url:sec-ecmascript-language-lexical-grammar; text:ECMAScript Lexical Grammar
 
 urlPrefix:https://webassembly.github.io/spec/core/; type:dfn; spec:wasm
     url:binary/modules.html#binary-customsec; text:custom section
@@ -273,6 +288,21 @@ fields represent mapped code that also has a mapped name.
 
 Note: Using file offsets was considered but rejected in favor of using line/column data to avoid becoming
 misaligned with the original due to platform-specific line endings. 
+
+### [=Mappings=] for generated JavaScript code
+
+Generated code positions that may have [=Mapping=] entries are defined in terms of *input elements*
+as per [=ECMAScript Lexical Grammar=]:
+
+1. [=Mapping=] entries must point to the first code point of the source text matched by
+    [=IdentifierName=], [=PrivateIdentifier=], [=Punctuator=], [=DivPunctuator=], [=RightBracePunctuator=],
+    [=NumericLiteral=], [=RegularExpressionLiteral=], [=Template=] and [=TemplateSubstitutionTail=].
+
+1. [=Mapping=] entries may point to any code point of the source text matched by
+    [=Comment=], [=HashbangComment=] and [=StringLiteral=].
+
+1. [=Mapping=] entries must not point to any code point of the source text matched by
+    [=WhiteSpace=] and [=LineTerminator=].
 
 Resolving Sources {#resolving-sources}
 --------------------------------------

--- a/source-map.bs
+++ b/source-map.bs
@@ -296,13 +296,11 @@ as per [=ECMAScript Lexical Grammar=]:
 
 1. [=Mapping=] entries must point to the first code point of the source text matched by
     [=IdentifierName=], [=PrivateIdentifier=], [=Punctuator=], [=DivPunctuator=], [=RightBracePunctuator=],
-    [=NumericLiteral=], [=RegularExpressionLiteral=], [=Template=] and [=TemplateSubstitutionTail=].
+    [=NumericLiteral=] and [=RegularExpressionLiteral=].
 
 1. [=Mapping=] entries may point to any code point of the source text matched by
-    [=Comment=], [=HashbangComment=] and [=StringLiteral=].
-
-1. [=Mapping=] entries must not point to any code point of the source text matched by
-    [=WhiteSpace=] and [=LineTerminator=].
+    [=Comment=], [=HashbangComment=], [=StringLiteral=], [=Template=],
+    [=TemplateSubstitutionTail=], [=WhiteSpace=] and [=LineTerminator=].
 
 Resolving Sources {#resolving-sources}
 --------------------------------------

--- a/source-map.bs
+++ b/source-map.bs
@@ -292,13 +292,13 @@ misaligned with the original due to platform-specific line endings.
 ### [=Mappings=] for generated JavaScript code
 
 Generated code positions that may have [=Mapping=] entries are defined in terms of *input elements*
-as per [=ECMAScript Lexical Grammar=]:
+as per [=ECMAScript Lexical Grammar=]. [=Mapping=] entries must point to either:
 
-1. [=Mapping=] entries must point to the first code point of the source text matched by
+1. the first code point of the source text matched by
     [=IdentifierName=], [=PrivateIdentifier=], [=Punctuator=], [=DivPunctuator=], [=RightBracePunctuator=],
     [=NumericLiteral=] and [=RegularExpressionLiteral=].
 
-1. [=Mapping=] entries may point to any code point of the source text matched by
+1. any code point of the source text matched by
     [=Comment=], [=HashbangComment=], [=StringLiteral=], [=Template=],
     [=TemplateSubstitutionTail=], [=WhiteSpace=] and [=LineTerminator=].
 


### PR DESCRIPTION
This PR is a initial take to at least clarify on a very basic level where we allow mappings for JavaScript. The current draft proposes to use "input elements" instead of "ECMAScript tokens" since generators might want to map comments as well (e.g. a TypeScript -> JavaScript with JSDoc transformer that maps the `@param` back to the TS type annotation).

The main reasoning behind the current draft is that it seldom make sense to have mappings in the middle of tokens. E.g. with `let foo = 5;`, you don't really need a mapping for the `o` in `foo`. The exception (I think) are string literals where minifiers could combine multiline string literals into a single literal. Template literals might also fall under this category so we could move them down to the second bullet point.

I don't see a use case for mapping white space and line terminators, but if there is a valid use-case we should also move them to the second bullet point.

Note: I plan to do a followup where we recommend some AST productions where generators "should" emit mappings to better facilitate stack trace deobfuscation/debugging/etc. But this is kinda tricky since engines don't really agree on where `Error.stack` frames point to w.r.t. to the ECMAScript AST, so we'd have to cover all or at least the major use cases in the major browsers/runtimes.