### PR TITLE
Add security warning for ambiguous source maps

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -777,6 +777,19 @@ without parsing|without parsing=] gives `foo.js.map`.
 
 </div>
 
+<div class="issue">
+Having multiple ways to extract a source map URL, that can lead to different
+results, can have negative security and privacy implications. Implementations
+that need to detect which source maps are potentially going to be loaded are
+strongly encouraged to always apply both algorithms, rather than just assuming
+that they will give the same result.
+
+A fix to this problem is worked on, and will likely involve early returning
+from the below algorithms whenever there is a comment (or comment-like) that
+contain the characters U+0060 (&#x60;), U+0022 ("), or U+0027 ('), or the the
+sequence U+002A U+002F (*/).
+</div>
+
 #### Extraction methods for JavaScript sources #### {#extraction-javascript}
 
 To <dfn export>extract a Source Map URL from JavaScript through parsing</dfn> a [=string=] |source|,

--- a/source-map.bs
+++ b/source-map.bs
@@ -786,7 +786,7 @@ that they will give the same result.
 
 A fix to this problem is worked on, and will likely involve early returning
 from the below algorithms whenever there is a comment (or comment-like) that
-contain the characters U+0060 (&#x60;), U+0022 ("), or U+0027 ('), or the the
+contains the characters U+0060 (&#x60;), U+0022 ("), or U+0027 ('), or the the
 sequence U+002A U+002F (*/).
 </div>
 

--- a/source-map.bs
+++ b/source-map.bs
@@ -784,7 +784,7 @@ that need to detect which source maps are potentially going to be loaded are
 strongly encouraged to always apply both algorithms, rather than just assuming
 that they will give the same result.
 
-A fix to this problem is worked on, and will likely involve early returning
+A fix to this problem is being worked on, and will likely involve early returning
 from the below algorithms whenever there is a comment (or comment-like) that
 contains the characters U+0060 (&#x60;), U+0022 ("), or U+0027 ('), or the the
 sequence U+002A U+002F (*/).


### PR DESCRIPTION
It was pointed out during the October 2024 plenary that being able to cause a tool to perform a network request can be used for tracking purposes, and thus it should be possible to statically know whether a file links to a source map or not.

The problem is that, given that we have multiple linking methods _that give different results_, it's not unlikely that ambiguous source map comments can skip through reviews and checks.

There was a solution that we collectively came up with, but we did not want to change the specification at this point given that we need to discuss it in TG4 and go through the implications of it.

Approval on publishing the first edition of our spec was conditional of explicitly calling out (in a note / not normative section) the implications of the ambiguity, and how a potential solution would look like. Our specification already points to the living draft, and thus it's ok if we just work on the actual fix in the living draft.

The proposed fix is very likely to affect no actual usages of source maps, but we need to check in TG4 if it needs to be tweaked. I'll open an issue to better discuss it.

Examples of ambiguous comments:
```js
let a = `
//# sourceMappingURL=foo.map
// `;
```
```js
let a = "\
//# sourceMappingURL=foo.map"
```
```js
let a = '\
//# sourceMappingURL=foo.map'
```
```js
//# sourceMappingURL=bar.map
/*
//# sourceMappingURL=foo.map
// */
```

This PR needs to be merged **today**, because we need to start the 60 days period and this is a requirement for it. The pull request does not contain any normative changes, and is entirely an editorial decision.