### PR TITLE
Workflow: Add preview-branch.yml

### DIFF
--- a/.github/workflows/preview-branch.yml
+++ b/.github/workflows/preview-branch.yml
@@ -1,0 +1,18 @@
+name: Build preview branch
+on:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'gh-pages**'
+jobs:
+  main:
+    name: Build, validate and deploy to branch
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: ${{ format('gh-pages-{0}', github.ref_name) }}
+          TOOLCHAIN: bikeshed
+          SOURCE: source-map.bs
+          DESTINATION: 'index.html'


### PR DESCRIPTION
This PR adds a simple workflow intended for forks: For every push to a branch other than `main` and `gh-pages**` we'll build the spec's `index.html` and put it on a respective `gh-pages-<branch name>` branch.

Then folks can deploy that `gh-pages-<branch name>` to their GitHub pages with a single click in their respective forks and provide a preview for PRs to make reviewing it easier.