### PR TITLE
Use "greater than or equal to" for nameIndex

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -616,7 +616,7 @@ sources=] <dfn for="decode source map mappings">|sources|</dfn>, run the followi
                 be the result.
             1. If |relativeNameIndex| is not null, then:
                 1. Increase |nameIndex| by |relativeNameIndex|.
-                1. If |nameIndex| is negative or greater than |names|'s [=list/size=], [=optionally
+                1. If |nameIndex| is negative or greater than or equal to |names|'s [=list/size=], [=optionally
                     report an error=].
                 1. Else, set |decodedMapping|'s [=decoded mapping/name=] to |names|[|nameIndex|].
             1. If |position| does not point to the end of |segment|, [=optionally report an


### PR DESCRIPTION
This PR fixes an issue identified in the tests repo (https://github.com/tc39/source-map-tests/issues/25) for a small bug in name index range checking in the spec algorithm. It should check "greater than or equal to" (as done for `sourceIndex`) instead of "greater than".