### PR TITLE
Editorial: Add CSS to adjust list bullets to match ECMA

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -145,6 +145,17 @@ urlPrefix:https://webassembly.github.io/spec/core/; type:dfn; spec:wasm
 }
 </pre>
 
+<style>
+  /* match list styles of ecmarkup */
+  ol > li { list-style-type: decimal; }                       /* depth 1 */
+  ol ol > li { list-style-type: lower-alpha; }                /* depth 2 */
+  ol ol ol > li { list-style-type: lower-roman; }             /* depth 3 */
+  ol ol ol ol > li { list-style-type: decimal; }              /* depth 4 */
+  ol ol ol ol ol > li { list-style-type: lower-alpha; }       /* depth 5 */
+  ol ol ol ol ol ol > li { list-style-type: lower-roman; }    /* depth 6 */
+  ol ol ol ol ol ol ol > li { list-style-type: lower-roman; } /* depth 7+ is lower-roman */
+</style>
+
 <h2 class="no-num" id="intro">Introduction</h2>
 
 This Ecma Standard defines the Source Map Format, used for mapping transpiled source code back to the original sources.


### PR DESCRIPTION
Right now the draft PDF spec (in ECMA format) and the web spec don't align on the numbered bullet styles in algorithms. This PR changes the web version to match using CSS.

This also changes numbered bullets that aren't in algorithms, such as those in "5.1.2. Names for generated JavaScript code" (which is not in the 2024 branch) because we don't have a CSS class to distinguish them. I think in that particular case, we could just use unordered lists instead if we don't like the alternating bullets.