### PR TITLE
Advance Debug ID proposal to stage 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Older revisions:
 | ------------------------------------------------------------------------------------------ | ----------------------- | ------- |
 | [Scopes](https://github.com/tc39/source-map/blob/main/proposals/scopes.md)                 | Holger Benl, Simon Zünd | Stage 3 |
 | [Range Mappings](https://github.com/tc39/source-map/blob/main/proposals/range-mappings.md) | Tobias Koppers          | Stage 2 |
-| [Debug ID](https://github.com/tc39/source-map/blob/main/proposals/debug-id.md)             | Luca Forstner           | Stage 1 |
+| [Debug ID](https://github.com/tc39/source-map/blob/main/proposals/debug-id.md)             | Luca Forstner           | Stage 2 |
 | [Env](https://github.com/tc39/source-map/blob/main/proposals/env.md)                       | Nick Fitzgerald         | Stage 1 |
 
 ## License

--- a/proposals/debug-id.md
+++ b/proposals/debug-id.md
@@ -4,7 +4,7 @@ This document presents a proposal to add globally unique build or debug IDs to s
 
 ## Current Status
 
-Source maps proposal at stage 1 of the process, see [Our process document](https://github.com/tc39/source-map/blob/main/PROCESS.md)
+Source maps proposal at stage 2 of the process, see [Our process document](https://github.com/tc39/source-map/blob/main/PROCESS.md)
 
 ## Author
 


### PR DESCRIPTION
In the last TG4 monthly meeting we decided to advance the Debug ID proposal to stage 2 given the proposal is written out in detail and also has some adoption.

I am happy to wait a few more weeks to give people the opportunity to object.